### PR TITLE
Use ${srcdir} to locate patch instead of relative path

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-camera-calibration-parsers
 	pkgdesc = ROS - camera_calibration_parsers contains routines for reading and writing camera calibration parameters.
 	pkgver = 1.11.13
-	pkgrel = 5
+	pkgrel = 6
 	url = https://wiki.ros.org/camera_calibration_parsers
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ url='https://wiki.ros.org/camera_calibration_parsers'
 pkgname='ros-melodic-camera-calibration-parsers'
 pkgver='1.11.13'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=5
+pkgrel=6
 license=('BSD')
 
 ros_makedepends=(
@@ -46,7 +46,7 @@ sha256sums=('32a2e07724dec6eaaace21eae006274436d70d40bfe205249438570275c43cac'
 
 prepare() {
     cd "${srcdir}/${_dir}"
-    patch -uN CMakeLists.txt ../../../boost-fix.patch || return 1
+    patch -uN CMakeLists.txt ${srcdir}/boost-fix.patch || return 1
 }
 
 build() {


### PR DESCRIPTION
The relative path may work in many cases, but useing the ${srcdir}
reference should be more robust. For me, the package didn't build
with the relative path when building in a clean chroot environment.